### PR TITLE
Adicionar funcionalidade de gerenciamento de chaves DKIM

### DIFF
--- a/app/views/domains/setup.html.haml
+++ b/app/views/domains/setup.html.haml
@@ -61,6 +61,32 @@
     with the following content.
   %pre.codeBlock.u-margin= @domain.dkim_record
 
+  %h3.pageContent__subTitle Custom DKIM Key
+  - if @domain.custom_dkim_key?
+    %p.pageContent__text.u-green.u-bold
+      %span.label.label--green Custom Key
+      You are using a custom DKIM key for this domain.
+  - else
+    %p.pageContent__text.u-grey.u-bold
+      %span.label.label--grey Default Key
+      You are using the automatically generated DKIM key.
+
+  %p.pageContent__text
+    You can provide your own RSA private key below. This is optional and only recommended if you need to use a specific key for compatibility with other systems.
+    The key must be a valid RSA private key in PEM format.
+
+  = form_tag (@server ? update_dkim_key_organization_server_domain_path(organization, @server, @domain) : update_dkim_key_organization_domain_path(organization, @domain)), method: :patch, data: { turbo: false }, class: "form" do
+    .form-group
+      = text_area_tag :dkim_private_key, nil, class: "form-control input--code", rows: 10, placeholder: "-----BEGIN RSA PRIVATE KEY-----\n\n-----END RSA PRIVATE KEY-----", style: "width: 100%; font-family: 'Droid Sans Mono', fixed;"
+      %p.form-help.u-margin
+        Paste your RSA private key here. The key should be in PEM format.
+        %br
+        %strong Warning: 
+        Make sure to keep your private key secure and never share it publicly.
+
+    .form-group.u-margin
+      = submit_tag "Update DKIM Key", class: "button button--primary"
+
   %h3.pageContent__subTitle Return Path
   - if @domain.return_path_status == 'OK'
     %p.pageContent__text.u-green.u-bold

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,12 +12,18 @@ Rails.application.routes.draw do
       match :verify, on: :member, via: [:get, :post]
       get :setup, on: :member
       post :check, on: :member
+      member do
+        patch :update_dkim_key
+      end
     end
     resources :servers, except: [:index] do
       resources :domains, only: [:index, :new, :create, :destroy] do
         match :verify, on: :member, via: [:get, :post]
         get :setup, on: :member
         post :check, on: :member
+        member do
+          patch :update_dkim_key
+        end
       end
       resources :track_domains do
         post :toggle_ssl, on: :member

--- a/db/migrate/20250401203643_add_custom_dkim_key_to_domains.rb
+++ b/db/migrate/20250401203643_add_custom_dkim_key_to_domains.rb
@@ -1,0 +1,5 @@
+class AddCustomDkimKeyToDomains < ActiveRecord::Migration[7.0]
+  def change
+    add_column :domains, :custom_dkim_key, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20250402112911_remove_dkim_identifier_string.rb
+++ b/db/migrate/20250402112911_remove_dkim_identifier_string.rb
@@ -1,0 +1,5 @@
+class RemoveDKIMIdentifierString < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :domains, :dkim_identifier_string, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_02_112911) do
   create_table "additional_route_endpoints", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "route_id"
     t.string "endpoint_type"
@@ -97,8 +97,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.boolean "incoming", default: true
     t.string "owner_type"
     t.integer "owner_id"
-    t.string "dkim_identifier_string"
     t.boolean "use_for_any"
+    t.boolean "custom_dkim_key", default: false, null: false
     t.index ["server_id"], name: "index_domains_on_server_id"
     t.index ["uuid"], name: "index_domains_on_uuid", length: 8
   end

--- a/spec/factories/domain_factory.rb
+++ b/spec/factories/domain_factory.rb
@@ -4,31 +4,31 @@
 #
 # Table name: domains
 #
-#  id                     :integer          not null, primary key
-#  server_id              :integer
-#  uuid                   :string(255)
-#  name                   :string(255)
-#  verification_token     :string(255)
-#  verification_method    :string(255)
-#  verified_at            :datetime
-#  dkim_private_key       :text(65535)
-#  created_at             :datetime
-#  updated_at             :datetime
-#  dns_checked_at         :datetime
-#  spf_status             :string(255)
-#  spf_error              :string(255)
-#  dkim_status            :string(255)
-#  dkim_error             :string(255)
-#  mx_status              :string(255)
-#  mx_error               :string(255)
-#  return_path_status     :string(255)
-#  return_path_error      :string(255)
-#  outgoing               :boolean          default(TRUE)
-#  incoming               :boolean          default(TRUE)
-#  owner_type             :string(255)
-#  owner_id               :integer
-#  dkim_identifier_string :string(255)
-#  use_for_any            :boolean
+#  id                  :integer          not null, primary key
+#  custom_dkim_key     :boolean          default(FALSE), not null
+#  dkim_error          :string(255)
+#  dkim_private_key    :text(65535)
+#  dkim_status         :string(255)
+#  dns_checked_at      :datetime
+#  incoming            :boolean          default(TRUE)
+#  mx_error            :string(255)
+#  mx_status           :string(255)
+#  name                :string(255)
+#  outgoing            :boolean          default(TRUE)
+#  owner_type          :string(255)
+#  return_path_error   :string(255)
+#  return_path_status  :string(255)
+#  spf_error           :string(255)
+#  spf_status          :string(255)
+#  use_for_any         :boolean
+#  uuid                :string(255)
+#  verification_method :string(255)
+#  verification_token  :string(255)
+#  verified_at         :datetime
+#  created_at          :datetime
+#  updated_at          :datetime
+#  owner_id            :integer
+#  server_id           :integer
 #
 # Indexes
 #

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -4,31 +4,31 @@
 #
 # Table name: domains
 #
-#  id                     :integer          not null, primary key
-#  dkim_error             :string(255)
-#  dkim_identifier_string :string(255)
-#  dkim_private_key       :text(65535)
-#  dkim_status            :string(255)
-#  dns_checked_at         :datetime
-#  incoming               :boolean          default(TRUE)
-#  mx_error               :string(255)
-#  mx_status              :string(255)
-#  name                   :string(255)
-#  outgoing               :boolean          default(TRUE)
-#  owner_type             :string(255)
-#  return_path_error      :string(255)
-#  return_path_status     :string(255)
-#  spf_error              :string(255)
-#  spf_status             :string(255)
-#  use_for_any            :boolean
-#  uuid                   :string(255)
-#  verification_method    :string(255)
-#  verification_token     :string(255)
-#  verified_at            :datetime
-#  created_at             :datetime
-#  updated_at             :datetime
-#  owner_id               :integer
-#  server_id              :integer
+#  id                  :integer          not null, primary key
+#  custom_dkim_key     :boolean          default(FALSE), not null
+#  dkim_error          :string(255)
+#  dkim_private_key    :text(65535)
+#  dkim_status         :string(255)
+#  dns_checked_at      :datetime
+#  incoming            :boolean          default(TRUE)
+#  mx_error            :string(255)
+#  mx_status           :string(255)
+#  name                :string(255)
+#  outgoing            :boolean          default(TRUE)
+#  owner_type          :string(255)
+#  return_path_error   :string(255)
+#  return_path_status  :string(255)
+#  spf_error           :string(255)
+#  spf_status          :string(255)
+#  use_for_any         :boolean
+#  uuid                :string(255)
+#  verification_method :string(255)
+#  verification_token  :string(255)
+#  verified_at         :datetime
+#  created_at          :datetime
+#  updated_at          :datetime
+#  owner_id            :integer
+#  server_id           :integer
 #
 # Indexes
 #


### PR DESCRIPTION
- Implementada a ação `update_dkim_key` no DomainsController para manipular atualizações de chaves DKIM personalizadas.
- Adicionada validação para o formato de chave privada DKIM no modelo Domain.
- Atualizadas as visualizações para permitir que os usuários insiram e gerenciem suas chaves DKIM.
- Rotas modificadas para incluir o novo ponto de extremidade de atualização de chaves DKIM.
- Esquema de banco de dados ajustado para incluir o atributo `custom_dkim_key` e `dkim_identifier_string` removido.